### PR TITLE
feat(ui): add toolbar filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ Codex can update this list by toggling boxes and appending PR links. Each line h
   - [x] Leaving Done sets `done=false` and updates `updated` <!-- TASK:ui-dnd-undo --> (commit fc28ebd)
 - [x] Matrix filters by project <!-- TASK:ui-matrix-filters --> (commit 51d199b)
 
-- [ ] Toolbar filters and sorting <!-- TASK:ui-filters -->
-  - [ ] Project filter built from data plus All <!-- TASK:ui-filter-project -->
-  - [ ] Sort selector: Score, Due date, Title <!-- TASK:ui-sort -->
+- [x] Toolbar filters and sorting <!-- TASK:ui-filters --> (PR #8)
+  - [x] Project filter built from data plus All <!-- TASK:ui-filter-project --> (PR #8)
+  - [x] Sort selector: Score, Due date, Title <!-- TASK:ui-sort --> (PR #8)
 
 - [ ] Add task modal <!-- TASK:ui-add -->
   - [ ] Validate title and optional fields <!-- TASK:ui-add-validate -->

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,9 +246,6 @@ function GlobalToolbar({
       data-testid="workspace-toolbar"
     >
       <Stack spacing={{ base: 3, md: 4 }}>
-        <Text fontSize="sm" color="gray.500">
-          Filters apply across the workspace. Pick the projects you need and choose a sort for project lists.
-        </Text>
         <MatrixFilterChips options={filterOptions} active={activeFilters} onToggle={onToggleFilter}>
           <Menu>
             <MenuButton

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,10 @@ import {
   HStack,
   IconButton,
   Input,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -35,7 +39,7 @@ import {
   WrapItem,
   useDisclosure
 } from "@chakra-ui/react";
-import { CheckIcon, CheckCircleIcon, DeleteIcon, WarningTwoIcon } from "@chakra-ui/icons";
+import { CheckIcon, CheckCircleIcon, ChevronDownIcon, DeleteIcon, WarningTwoIcon } from "@chakra-ui/icons";
 import { motion } from "framer-motion";
 import { parseJSONL } from "./jsonl.js";
 import { bucket, score } from "./model.js";
@@ -148,7 +152,7 @@ function MatrixFilterChips({ options, active, onToggle, children }) {
   const extraItems = useMemo(() => Children.toArray(children), [children]);
 
   return (
-    <Wrap spacing={2} mt={1}>
+    <Wrap spacing={{ base: 2, md: 3 }} mt={1}>
       {options.map((option) => {
         const selected = active.includes(option);
         return (
@@ -225,6 +229,11 @@ function GlobalToolbar({
     []
   );
 
+  const activeSortLabel = useMemo(() => {
+    const match = sortOptions.find((option) => option.value === sortMode);
+    return match ? match.label : sortOptions[0].label;
+  }, [sortOptions, sortMode]);
+
   return (
     <Box
       bg="white"
@@ -237,45 +246,39 @@ function GlobalToolbar({
       data-testid="workspace-toolbar"
     >
       <Stack spacing={{ base: 3, md: 4 }}>
-        <Box>
-          <Heading size="sm" color="gray.700">
-            Workspace filters
-          </Heading>
-          <Text fontSize="sm" color="gray.500">
-            Choose which projects appear and how task lists are ordered.
-          </Text>
-        </Box>
+        <Text fontSize="sm" color="gray.500">
+          Filters apply across the workspace. Pick the projects you need and choose a sort for project lists.
+        </Text>
         <MatrixFilterChips options={filterOptions} active={activeFilters} onToggle={onToggleFilter}>
-          <Box
-            minW={{ base: "100%", sm: "220px" }}
-            bg="gray.50"
-            borderRadius="full"
-            px={3}
-            py={1.5}
-          >
-            <Text
-              fontSize="xs"
-              textTransform="uppercase"
-              letterSpacing="wide"
-              color="gray.500"
-              mb={1}
-            >
-              Sort projects
-            </Text>
-            <Select
-              size="sm"
-              value={sortMode}
-              onChange={(event) => onSortModeChange?.(event.target.value)}
-              bg="white"
+          <Menu>
+            <MenuButton
+              as={Button}
+              size="xs"
+              variant="outline"
+              colorScheme="purple"
+              rightIcon={<ChevronDownIcon />}
               data-testid="project-sort-select"
             >
-              {sortOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </Select>
-          </Box>
+              Sort: {activeSortLabel}
+            </MenuButton>
+            <MenuList>
+              {sortOptions.map((option) => {
+                const isActive = option.value === sortMode;
+                return (
+                  <MenuItem
+                    key={option.value}
+                    onClick={() => {
+                      if (isActive) return;
+                      onSortModeChange?.(option.value);
+                    }}
+                    fontWeight={isActive ? "semibold" : "normal"}
+                  >
+                    {option.label}
+                  </MenuItem>
+                );
+              })}
+            </MenuList>
+          </Menu>
         </MatrixFilterChips>
       </Stack>
     </Box>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -974,6 +974,10 @@ export default function App() {
   const lastSavedRef = useRef("");
   const saveTimeoutRef = useRef(null);
   const [saveState, setSaveState] = useState({ status: "idle" });
+  const hasUnassignedTasks = useMemo(
+    () => tasks.some((task) => !(task.project?.trim())),
+    [tasks]
+  );
   useEffect(() => {
     setProjects((prev) => {
       const derived = collectProjects(
@@ -990,19 +994,22 @@ export default function App() {
   useEffect(() => {
     setMatrixFilters((prev) => {
       if (prev.includes(ALL_PROJECTS)) return DEFAULT_MATRIX_FILTERS;
-      const allowed = new Set(projects.concat([UNASSIGNED_LABEL]));
+      const allowed = new Set(projects);
+      if (hasUnassignedTasks) {
+        allowed.add(UNASSIGNED_LABEL);
+      }
       const next = prev.filter((value) => value === ALL_PROJECTS || allowed.has(value));
       return next.length ? next : DEFAULT_MATRIX_FILTERS;
     });
-  }, [projects]);
+  }, [projects, hasUnassignedTasks]);
 
   const matrixFilterOptions = useMemo(() => {
     const options = [ALL_PROJECTS, ...projects];
-    if (!projects.includes(UNASSIGNED_LABEL)) {
+    if (hasUnassignedTasks) {
       options.push(UNASSIGNED_LABEL);
     }
     return options;
-  }, [projects]);
+  }, [projects, hasUnassignedTasks]);
 
   const clearPendingSave = useCallback(() => {
     if (saveTimeoutRef.current) {

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -1,0 +1,69 @@
+import { score } from "./model.js";
+import { ALL_PROJECTS, UNASSIGNED_LABEL } from "./matrix.js";
+
+export const TOOLBAR_SORTS = {
+  SCORE: "score",
+  DUE_DATE: "due-date",
+  TITLE: "title"
+};
+
+export function buildProjectFilterOptions(projects = []) {
+  const seen = new Set();
+  const options = [ALL_PROJECTS];
+  projects.forEach((project) => {
+    if (project && !seen.has(project)) {
+      options.push(project);
+      seen.add(project);
+    }
+  });
+  if (!seen.has(UNASSIGNED_LABEL)) {
+    options.push(UNASSIGNED_LABEL);
+  }
+  return options;
+}
+
+function normalizeDueValue(task) {
+  const due = task?.due;
+  if (!due) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(due);
+  if (Number.isNaN(parsed)) return Number.POSITIVE_INFINITY;
+  return parsed;
+}
+
+function compareTitle(a = "", b = "") {
+  return a.localeCompare(b, undefined, { sensitivity: "base" });
+}
+
+export function compareProjectItems(a, b, sortMode = TOOLBAR_SORTS.SCORE) {
+  const sort = sortMode ?? TOOLBAR_SORTS.SCORE;
+  if (a.task.done !== b.task.done) {
+    return a.task.done ? 1 : -1;
+  }
+
+  const scoreA = score(a.task ?? {});
+  const scoreB = score(b.task ?? {});
+  const dueA = normalizeDueValue(a.task);
+  const dueB = normalizeDueValue(b.task);
+  const titleDiff = compareTitle(a.task?.title, b.task?.title);
+
+  if (sort === TOOLBAR_SORTS.DUE_DATE) {
+    const dueDiff = dueA - dueB;
+    if (dueDiff !== 0) return dueDiff;
+  } else if (sort === TOOLBAR_SORTS.TITLE) {
+    if (titleDiff !== 0) return titleDiff;
+  } else {
+    const scoreDiff = scoreB - scoreA;
+    if (scoreDiff !== 0) return scoreDiff;
+  }
+
+  const scoreDiff = scoreB - scoreA;
+  if (scoreDiff !== 0) return scoreDiff;
+
+  if (titleDiff !== 0) return titleDiff;
+
+  return a.index - b.index;
+}
+
+export function sortProjectItems(items = [], sortMode = TOOLBAR_SORTS.SCORE) {
+  return items.slice().sort((a, b) => compareProjectItems(a, b, sortMode));
+}

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -109,7 +109,7 @@ export function projectSectionsFrom(
     }))
     .sort((a, b) => compareInsensitive(a.name, b.name));
 
-  if (allowUnassigned) {
+  if (allowUnassigned && unassigned.length > 0) {
     entries.push({
       name: UNASSIGNED_LABEL,
       projectKey: undefined,

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -78,6 +78,6 @@ describe("matrix sorting", () => {
     ];
 
     const diff = compareMatrixEntries(sample[0], sample[1], MATRIX_SORTS.LOW_EFFORT);
-    expect(Math.sign(diff)).toBeGreaterThan(0);
+    expect(Math.sign(diff) > 0).toBe(true);
   });
 });

--- a/test/toolbar.test.js
+++ b/test/toolbar.test.js
@@ -4,7 +4,8 @@ import {
   TOOLBAR_SORTS,
   buildProjectFilterOptions,
   compareProjectItems,
-  sortProjectItems
+  sortProjectItems,
+  projectSectionsFrom
 } from "../src/toolbar.js";
 
 describe("toolbar project filter options", () => {
@@ -14,6 +15,35 @@ describe("toolbar project filter options", () => {
     expect(options.includes("Alpha")).toBe(true);
     expect(options.includes("Beta")).toBe(true);
     expect(options.at(-1)).toBe(UNASSIGNED_LABEL);
+  });
+});
+
+describe("project sections", () => {
+  const tasks = [
+    { title: "Audit", project: "Alpha", importance: 3, urgency: 1 },
+    { title: "Prototype", project: "Beta", importance: 4, urgency: 2 },
+    { title: "Spec", project: "Alpha", importance: 5, urgency: 4 },
+    { title: "Backlog" }
+  ];
+  const projectList = ["Alpha", "Beta"];
+
+  it("returns all sections when filters include all projects", () => {
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.SCORE, [ALL_PROJECTS]);
+    expect(sections.length).toBe(3);
+    expect(sections.map((section) => section.name)).toEqual(["Alpha", "Beta", UNASSIGNED_LABEL]);
+  });
+
+  it("includes only matching projects when filters are scoped", () => {
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.SCORE, ["Beta"]);
+    expect(sections.length).toBe(1);
+    expect(sections[0].name).toBe("Beta");
+  });
+
+  it("includes unassigned section when requested", () => {
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.TITLE, [UNASSIGNED_LABEL]);
+    expect(sections.length).toBe(1);
+    expect(sections[0].name).toBe(UNASSIGNED_LABEL);
+    expect(sections[0].items.map((entry) => entry.index)).toEqual([3]);
   });
 });
 

--- a/test/toolbar.test.js
+++ b/test/toolbar.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "./test-utils.js";
+import { ALL_PROJECTS, UNASSIGNED_LABEL } from "../src/matrix.js";
+import {
+  TOOLBAR_SORTS,
+  buildProjectFilterOptions,
+  compareProjectItems,
+  sortProjectItems
+} from "../src/toolbar.js";
+
+describe("toolbar project filter options", () => {
+  it("returns All plus unique project names and unassigned", () => {
+    const options = buildProjectFilterOptions(["Alpha", "Beta", "Alpha"]);
+    expect(options[0]).toBe(ALL_PROJECTS);
+    expect(options.includes("Alpha")).toBe(true);
+    expect(options.includes("Beta")).toBe(true);
+    expect(options.at(-1)).toBe(UNASSIGNED_LABEL);
+  });
+});
+
+describe("toolbar project sorting", () => {
+  const sample = [
+    { index: 0, task: { title: "Write docs", importance: 3, urgency: 2, effort: 1 } },
+    { index: 1, task: { title: "Review PR", importance: 4, urgency: 4, effort: 1 } },
+    { index: 2, task: { title: "Plan sprint", importance: 4, urgency: 1, effort: 3 } },
+    { index: 3, task: { title: "Archive", done: true, importance: 5, urgency: 5, effort: 1 } }
+  ];
+
+  it("keeps incomplete tasks before completed ones", () => {
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.SCORE);
+    expect(sorted.at(-1).task.done).toBe(true);
+  });
+
+  it("sorts by score descending when mode is score", () => {
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.SCORE);
+    expect(sorted[0].task.title).toBe("Review PR");
+  });
+
+  it("sorts by due date ascending when mode is due date", () => {
+    const items = [
+      { index: 0, task: { title: "B", due: "2025-01-01" } },
+      { index: 1, task: { title: "A", due: "2024-12-01" } },
+      { index: 2, task: { title: "C" } }
+    ];
+    const sorted = sortProjectItems(items, TOOLBAR_SORTS.DUE_DATE);
+    expect(sorted.map((item) => item.task.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("falls back to alphabetical ordering when titles differ", () => {
+    const a = { index: 0, task: { title: "alpha" } };
+    const b = { index: 1, task: { title: "Beta" } };
+    const comparison = compareProjectItems(a, b, TOOLBAR_SORTS.TITLE);
+    expect(comparison < 0).toBe(true);
+  });
+});

--- a/test/toolbar.test.js
+++ b/test/toolbar.test.js
@@ -45,6 +45,18 @@ describe("project sections", () => {
     expect(sections[0].name).toBe(UNASSIGNED_LABEL);
     expect(sections[0].items.map((entry) => entry.index)).toEqual([3]);
   });
+
+  it("omits unassigned section when there are no unassigned tasks", () => {
+    const assignedOnly = tasks.slice(0, 3);
+    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.SCORE, [ALL_PROJECTS]);
+    expect(sections.map((section) => section.name)).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("returns no sections when filtering for unassigned without matches", () => {
+    const assignedOnly = tasks.slice(0, 3);
+    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.SCORE, [UNASSIGNED_LABEL]);
+    expect(sections.length).toBe(0);
+  });
 });
 
 describe("toolbar project sorting", () => {


### PR DESCRIPTION
## Summary
- add a workspace toolbar that reuses the priority matrix chips globally
- apply the project sort dropdown across project sections with refreshed layout and styling
- cover the new filtering helpers with node:test specs

## Testing
- npm test