### PR TITLE
feat(ui): refresh priority matrix cards

### DIFF
--- a/src/components/MatrixQuadrant.jsx
+++ b/src/components/MatrixQuadrant.jsx
@@ -15,6 +15,8 @@ export default function MatrixQuadrant({
   onEffortChange
 }) {
   const [isHover, setHover] = useState(false);
+  const baseGradient = `linear(to-br, ${colorScheme}.50, white)`;
+  const hoverGradient = `linear(to-br, ${colorScheme}.100, white)`;
 
   const handleDragOver = useCallback(
     (event) => {
@@ -48,13 +50,13 @@ export default function MatrixQuadrant({
     <Box
       borderWidth="1px"
       borderRadius="2xl"
-      bg="white"
+      bgGradient={isHover ? hoverGradient : baseGradient}
       p={5}
       boxShadow={isHover ? "xl" : "md"}
       display="flex"
       flexDirection="column"
-      gap={4}
-      borderColor={isHover ? "blue.400" : "gray.100"}
+      gap={3.5}
+      borderColor={isHover ? `${colorScheme}.300` : "gray.100"}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -73,7 +75,7 @@ export default function MatrixQuadrant({
         </Badge>
       </Flex>
       {items.length ? (
-        <Stack as="ul" spacing={3}>
+        <Stack as="ul" spacing={2.5}>
           {items.map((item) => (
             <TaskCard
               key={item.index}

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,16 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
-import { Box, Flex, Heading, HStack, Tag, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, Tag, Text, Wrap, WrapItem } from "@chakra-ui/react";
 import { CheckIcon } from "@chakra-ui/icons";
 import { motion } from "framer-motion";
 import EffortSlider from "../EffortSlider.jsx";
-import { score } from "../model.js";
+import { classifyTaskPriority } from "../matrix.js";
 
 const MotionCircle = motion(Box);
 
 export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, draggable = false }) {
-  const { task, index } = item;
+  const { task, index, priority: providedPriority } = item;
   const [isPopping, setPopping] = useState(false);
   const [isDragging, setDragging] = useState(false);
+  const priority = providedPriority ?? classifyTaskPriority(task);
+  const urgencyColorScheme = priority.isUrgent ? "red" : "gray";
+  const importanceColorScheme = priority.isImportant ? "teal" : "gray";
 
   const handleEffortUpdate = useCallback(
     (value) => {
@@ -61,19 +64,21 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
       cursor={draggable ? "grab" : "pointer"}
       borderWidth="1px"
       borderRadius="xl"
-      p={4}
+      p={3.5}
       bg={task.done ? "gray.100" : "white"}
       boxShadow={isDragging ? "lg" : "sm"}
       transition="all 0.15s ease"
       _hover={{ boxShadow: "lg", transform: "translateY(-2px)" }}
       display="flex"
       flexDirection="column"
-      gap={3}
+      gap={2.5}
     >
-      <Flex align="center" gap={3}>
+      <Flex align="flex-start" gap={3}>
         <MotionCircle
-          w={8}
-          h={8}
+          boxSize={8}
+          minW={8}
+          minH={8}
+          flexShrink={0}
           borderRadius="full"
           borderWidth="2px"
           borderColor={task.done ? "green.400" : "gray.300"}
@@ -91,11 +96,11 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
         >
           {task.done ? <CheckIcon w={3} h={3} /> : null}
         </MotionCircle>
-        <Box>
-          <Heading as="h3" size="sm">
+        <Box flex="1" minW={0}>
+          <Heading as="h3" size="xs" noOfLines={2}>
             {task.title}
           </Heading>
-          <Text fontSize="sm" color="gray.500">
+          <Text fontSize="xs" color="gray.500" noOfLines={2}>
             {task.notes ? task.notes : "Click to edit details"}
           </Text>
         </Box>
@@ -108,11 +113,32 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
       >
         <EffortSlider value={task.effort} onChange={handleEffortUpdate} size="sm" isCompact />
       </Box>
-      <HStack spacing={2} flexWrap="wrap">
-        {task.project ? <Tag colorScheme="purple">{task.project}</Tag> : null}
-        {task.due ? <Tag colorScheme="orange">Due {task.due}</Tag> : null}
-        <Tag colorScheme="blue">Score {score(task)}</Tag>
-      </HStack>
+      <Wrap spacing={1.5} shouldWrapChildren>
+        <WrapItem>
+          <Tag size="sm" variant="subtle" colorScheme={urgencyColorScheme}>
+            {priority.urgencyLabel}
+          </Tag>
+        </WrapItem>
+        <WrapItem>
+          <Tag size="sm" variant="subtle" colorScheme={importanceColorScheme}>
+            {priority.importanceLabel}
+          </Tag>
+        </WrapItem>
+        {task.project ? (
+          <WrapItem>
+            <Tag size="sm" variant="subtle" colorScheme="purple">
+              {task.project}
+            </Tag>
+          </WrapItem>
+        ) : null}
+        {task.due ? (
+          <WrapItem>
+            <Tag size="sm" variant="subtle" colorScheme="orange">
+              Due {task.due}
+            </Tag>
+          </WrapItem>
+        ) : null}
+      </Wrap>
     </Box>
   );
 }

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -1,4 +1,4 @@
-import { score } from "./model.js";
+import { bucket, score } from "./model.js";
 
 export const ALL_PROJECTS = "__all__";
 export const UNASSIGNED_LABEL = "Unassigned";
@@ -42,4 +42,21 @@ export function compareMatrixEntries(a, b, sortMode = MATRIX_SORTS.SCORE) {
 
 export function sortMatrixEntries(entries, sortMode = MATRIX_SORTS.SCORE) {
   return entries.slice().sort((a, b) => compareMatrixEntries(a, b, sortMode));
+}
+
+export function classifyTaskPriority(task, now = new Date()) {
+  const rawUrgency = task?.urgency;
+  const rawImportance = task?.importance;
+  const urgencyScore = rawUrgency ?? 0;
+  const importanceScore = rawImportance ?? 0;
+  const dueBucket = bucket(task, now);
+  const isUrgent = urgencyScore >= 3 || (rawUrgency == null && dueBucket === "Today");
+  const isImportant = importanceScore >= 3;
+
+  return {
+    isUrgent,
+    isImportant,
+    urgencyLabel: isUrgent ? "Urgent" : "Can wait",
+    importanceLabel: isImportant ? "Important" : "Low priority"
+  };
 }


### PR DESCRIPTION
## Summary
- add a shared classifier to describe each task's urgency and importance
- surface the urgency/importance chips on task cards with denser typography and layout tweaks
- update matrix quadrants with softer gradients and spacing to keep things playful while handling more cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafea7d05c833198d67c8abd8c4b23