### PR TITLE
feat: refresh priority matrix cards

### DIFF
--- a/src/components/MatrixQuadrant.jsx
+++ b/src/components/MatrixQuadrant.jsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react";
-import { Badge, Box, Flex, Heading, Stack, Text } from "@chakra-ui/react";
+import { useCallback, useMemo, useState } from "react";
+import { Badge, Box, Flex, Heading, Stack, Text, useToken } from "@chakra-ui/react";
 import TaskCard from "./TaskCard.jsx";
 
 export default function MatrixQuadrant({
@@ -15,6 +15,10 @@ export default function MatrixQuadrant({
   onEffortChange
 }) {
   const [isHover, setHover] = useState(false);
+  const [accentColor, borderHighlight] = useToken(
+    "colors",
+    useMemo(() => [`${colorScheme}.50`, `${colorScheme}.300`], [colorScheme])
+  );
 
   const handleDragOver = useCallback(
     (event) => {
@@ -54,7 +58,8 @@ export default function MatrixQuadrant({
       display="flex"
       flexDirection="column"
       gap={4}
-      borderColor={isHover ? "blue.400" : "gray.100"}
+      borderColor={isHover ? borderHighlight : "gray.100"}
+      backgroundImage={isHover && accentColor ? `linear-gradient(135deg, ${accentColor}, white)` : undefined}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -73,7 +78,7 @@ export default function MatrixQuadrant({
         </Badge>
       </Flex>
       {items.length ? (
-        <Stack as="ul" spacing={3}>
+        <Stack as="ul" spacing={2.5}>
           {items.map((item) => (
             <TaskCard
               key={item.index}

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
-import { Box, Flex, Heading, HStack, Tag, Text } from "@chakra-ui/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, Flex, HStack, Stack, Tag, Text } from "@chakra-ui/react";
 import { CheckIcon } from "@chakra-ui/icons";
 import { motion } from "framer-motion";
 import EffortSlider from "../EffortSlider.jsx";
-import { score } from "../model.js";
+import { getImportanceStatus, getUrgencyStatus } from "../utils/prioritization.js";
 
 const MotionCircle = motion(Box);
 
@@ -11,6 +11,9 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
   const { task, index } = item;
   const [isPopping, setPopping] = useState(false);
   const [isDragging, setDragging] = useState(false);
+
+  const urgencyChip = useMemo(() => getUrgencyStatus(task), [task]);
+  const importanceChip = useMemo(() => getImportanceStatus(task), [task]);
 
   const handleEffortUpdate = useCallback(
     (value) => {
@@ -61,16 +64,16 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
       cursor={draggable ? "grab" : "pointer"}
       borderWidth="1px"
       borderRadius="xl"
-      p={4}
-      bg={task.done ? "gray.100" : "white"}
-      boxShadow={isDragging ? "lg" : "sm"}
+      p={3.5}
+      bg={task.done ? "gray.50" : "white"}
+      boxShadow={isDragging ? "xl" : "md"}
       transition="all 0.15s ease"
-      _hover={{ boxShadow: "lg", transform: "translateY(-2px)" }}
+      _hover={{ boxShadow: "xl", transform: "translateY(-2px)", borderColor: "blue.200" }}
       display="flex"
       flexDirection="column"
       gap={3}
     >
-      <Flex align="center" gap={3}>
+      <Flex align="flex-start" gap={3}>
         <MotionCircle
           w={8}
           h={8}
@@ -88,17 +91,40 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
           whileTap={{ scale: 0.9 }}
           animate={isPopping ? { scale: [1, 1.2, 1], rotate: [0, -5, 5, 0] } : {}}
           transition={{ duration: 0.25, ease: "easeOut" }}
+          flexShrink={0}
         >
           {task.done ? <CheckIcon w={3} h={3} /> : null}
         </MotionCircle>
-        <Box>
-          <Heading as="h3" size="sm">
+        <Stack spacing={2} flex="1" minWidth={0} pt={0.5}>
+          <Text fontSize="sm" fontWeight="semibold" noOfLines={2}>
             {task.title}
-          </Heading>
-          <Text fontSize="sm" color="gray.500">
-            {task.notes ? task.notes : "Click to edit details"}
           </Text>
-        </Box>
+          <Text fontSize="xs" color="gray.500" noOfLines={2}>
+            {task.notes ? task.notes : "Add more context to keep future you on track."}
+          </Text>
+          <HStack spacing={2} flexWrap="wrap">
+            {urgencyChip ? (
+              <Tag size="sm" variant="subtle" colorScheme={urgencyChip.colorScheme}>
+                {urgencyChip.label}
+              </Tag>
+            ) : null}
+            {importanceChip ? (
+              <Tag size="sm" variant="subtle" colorScheme={importanceChip.colorScheme}>
+                {importanceChip.label}
+              </Tag>
+            ) : null}
+            {task.project ? (
+              <Tag size="sm" variant="subtle" colorScheme="purple">
+                {task.project}
+              </Tag>
+            ) : null}
+            {task.due ? (
+              <Tag size="sm" variant="subtle" colorScheme="orange">
+                Due {task.due}
+              </Tag>
+            ) : null}
+          </HStack>
+        </Stack>
       </Flex>
       <Box
         onClick={(event) => event.stopPropagation()}
@@ -108,11 +134,6 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
       >
         <EffortSlider value={task.effort} onChange={handleEffortUpdate} size="sm" isCompact />
       </Box>
-      <HStack spacing={2} flexWrap="wrap">
-        {task.project ? <Tag colorScheme="purple">{task.project}</Tag> : null}
-        {task.due ? <Tag colorScheme="orange">Due {task.due}</Tag> : null}
-        <Tag colorScheme="blue">Score {score(task)}</Tag>
-      </HStack>
     </Box>
   );
 }

--- a/src/utils/prioritization.js
+++ b/src/utils/prioritization.js
@@ -1,0 +1,25 @@
+import { bucket } from "../model.js";
+
+export function getUrgencyStatus(task, now = new Date()) {
+  const rawUrgency = task?.urgency;
+  const urgencyScore = rawUrgency ?? 0;
+  const dueBucket = bucket(task, now);
+  const isUrgent = urgencyScore >= 3 || (rawUrgency == null && dueBucket === "Today");
+
+  if (isUrgent) {
+    return { label: "Urgent", colorScheme: "pink" };
+  }
+
+  return { label: "Can wait", colorScheme: "teal" };
+}
+
+export function getImportanceStatus(task) {
+  const importanceScore = task?.importance ?? 0;
+  const isImportant = importanceScore >= 3;
+
+  if (isImportant) {
+    return { label: "Important", colorScheme: "purple" };
+  }
+
+  return { label: "Low priority", colorScheme: "gray" };
+}


### PR DESCRIPTION
## Summary
- add prioritization utilities to describe urgency and importance for tasks
- redesign task cards with compact typography and status chips tuned for the priority matrix
- update quadrant styling to keep hover feedback playful while handling dense task lists

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68cafea7d05c833198d67c8abd8c4b23