### PR TITLE
fix: anchor edit modal actions

### DIFF
--- a/src/EffortSlider.jsx
+++ b/src/EffortSlider.jsx
@@ -25,7 +25,14 @@ function describeEffort(value) {
   return { label: "Deep focus", colorScheme: "red" };
 }
 
-export function EffortSlider({ value, onChange, size = "md", isCompact = false, defaultValue = DEFAULT_EFFORT }) {
+export function EffortSlider({
+  value,
+  onChange,
+  size = "md",
+  isCompact = false,
+  defaultValue = DEFAULT_EFFORT,
+  isAlwaysVisible = false
+}) {
   const [internalValue, setInternalValue] = useState(() => clampEffort(value ?? defaultValue));
   const committedValueRef = useRef(clampEffort(value ?? defaultValue));
   const [isExpanded, setIsExpanded] = useState(false);
@@ -60,9 +67,10 @@ export function EffortSlider({ value, onChange, size = "md", isCompact = false, 
   const badgeVariant = hasDefinedValue ? "solid" : "subtle";
 
   const fontSize = size === "sm" ? "xs" : "sm";
-  const isSliderVisible = isExpanded || isHovering || isFocused;
+  const isSliderVisible = isAlwaysVisible || isExpanded || isHovering || isFocused;
 
   const handleToggleVisibility = () => {
+    if (isAlwaysVisible) return;
     setIsExpanded((prev) => {
       const next = !prev;
       if (!next) {
@@ -72,6 +80,23 @@ export function EffortSlider({ value, onChange, size = "md", isCompact = false, 
       return next;
     });
   };
+
+  const handleBadgeKeyDown = (event) => {
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      handleToggleVisibility();
+    }
+  };
+
+  const toggleProps = isAlwaysVisible
+    ? { as: "span", cursor: "default" }
+    : {
+        as: "button",
+        type: "button",
+        cursor: "pointer",
+        onClick: handleToggleVisibility,
+        onKeyDown: handleBadgeKeyDown
+      };
 
   return (
     <Box
@@ -90,25 +115,23 @@ export function EffortSlider({ value, onChange, size = "md", isCompact = false, 
         </Text>
         <HStack spacing={2} align="center">
           <Badge
-            as="button"
-            type="button"
-            onClick={handleToggleVisibility}
-            onKeyDown={(event) => {
-              if (event.key === " " || event.key === "Enter") {
-                event.preventDefault();
-                handleToggleVisibility();
-              }
-            }}
+            {...toggleProps}
             colorScheme={descriptor.colorScheme}
             variant={badgeVariant}
             fontSize={fontSize}
             borderRadius="full"
             px={3}
             py={0.5}
-            aria-pressed={isExpanded}
+            aria-pressed={isAlwaysVisible ? undefined : isExpanded}
             aria-controls={sliderId}
             aria-expanded={isSliderVisible}
-            title={isSliderVisible ? "Hide effort slider" : "Adjust effort"}
+            title={
+              isAlwaysVisible
+                ? "Effort level"
+                : isSliderVisible
+                ? "Hide effort slider"
+                : "Adjust effort"
+            }
           >
             {badgeText}
           </Badge>

--- a/src/components/AddTaskModal.jsx
+++ b/src/components/AddTaskModal.jsx
@@ -5,6 +5,8 @@ import {
   FormErrorMessage,
   FormLabel,
   Input,
+  InputGroup,
+  InputLeftElement,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -12,25 +14,24 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  NumberInput,
-  NumberInputField,
-  SimpleGrid,
   Select,
+  SimpleGrid,
   Stack,
+  Switch,
   Textarea
 } from "@chakra-ui/react";
 import EffortSlider from "../EffortSlider.jsx";
-import { sanitizeNumber, parseTags } from "../utils/taskFields.js";
+import { sanitizeNumber } from "../utils/taskFields.js";
+import { WORKSPACE_HEADER_MENU_STYLES } from "./componentTokens.js";
 
 export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreateProject }) {
   const [form, setForm] = useState({
     title: "",
     project: "",
     due: "",
-    importance: "",
-    urgency: "",
+    importance: false,
+    urgency: false,
     effort: 3,
-    tags: "",
     notes: "",
     projectMode: "none",
     newProjectName: ""
@@ -45,16 +46,21 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
       title: "",
       project: "",
       due: "",
-      importance: "",
-      urgency: "",
+      importance: false,
+      urgency: false,
       effort: 3,
-      tags: "",
       notes: "",
       projectMode: "none",
       newProjectName: ""
     });
     setError("");
     setProjectError("");
+    requestAnimationFrame(() => {
+      if (titleRef.current) {
+        titleRef.current.focus();
+        titleRef.current.select();
+      }
+    });
   }, [isOpen]);
 
   const handleChange = useCallback((field, value) => {
@@ -106,10 +112,9 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
         title,
         project: projectValue,
         due: form.due.trim() || undefined,
-        importance: sanitizeNumber(form.importance),
-        urgency: sanitizeNumber(form.urgency),
+        importance: form.importance ? 5 : undefined,
+        urgency: form.urgency ? 5 : undefined,
         effort: sanitizeNumber(form.effort),
-        tags: parseTags(form.tags),
         notes: form.notes.trim() || undefined
       };
 
@@ -126,7 +131,15 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
   return (
     <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={titleRef} size="lg">
       <ModalOverlay />
-      <ModalContent as="form" onSubmit={handleSubmit}>
+      <ModalContent
+        as="form"
+        onSubmit={handleSubmit}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            handleSubmit(event);
+          }
+        }}
+      >
         <ModalHeader>Add task</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
@@ -144,6 +157,9 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
               <FormControl isInvalid={Boolean(projectError)}>
                 <FormLabel>Project</FormLabel>
                 <Select
+                  variant="filled"
+                  focusBorderColor="blue.400"
+                  size="md"
                   value={
                     form.projectMode === "new" ? "__new__" : form.project || ""
                   }
@@ -160,6 +176,8 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
                 {form.projectMode === "new" ? (
                   <Input
                     mt={2}
+                    variant="filled"
+                    focusBorderColor="blue.400"
                     placeholder="New project name"
                     value={form.newProjectName}
                     onChange={(event) => handleNewProjectNameChange(event.target.value)}
@@ -169,56 +187,58 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
               </FormControl>
               <FormControl>
                 <FormLabel>Due date</FormLabel>
-                <Input
-                  type="date"
-                  value={form.due}
-                  onChange={(event) => handleChange("due", event.target.value)}
+                <InputGroup>
+                  <InputLeftElement pointerEvents="none" color="gray.400">
+                    📅
+                  </InputLeftElement>
+                  <Input
+                    pl={10}
+                    type="date"
+                    variant="filled"
+                    focusBorderColor="blue.400"
+                    value={form.due}
+                    onChange={(event) => handleChange("due", event.target.value)}
+                  />
+                </InputGroup>
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <Switch
+                  id="importance-toggle"
+                  isChecked={form.importance}
+                  onChange={(event) => handleChange("importance", event.target.checked)}
+                  colorScheme="purple"
+                  mr={3}
                 />
+                <FormLabel htmlFor="importance-toggle" mb={0}>
+                  Important
+                </FormLabel>
               </FormControl>
-              <FormControl>
-                <FormLabel>Importance</FormLabel>
-                <NumberInput
-                  min={0}
-                  max={5}
-                  value={form.importance}
-                  onChange={(value) => handleChange("importance", value)}
-                >
-                  <NumberInputField placeholder="0-5" />
-                </NumberInput>
-              </FormControl>
-              <FormControl>
-                <FormLabel>Urgency</FormLabel>
-                <NumberInput
-                  min={0}
-                  max={5}
-                  value={form.urgency}
-                  onChange={(value) => handleChange("urgency", value)}
-                >
-                  <NumberInputField placeholder="0-5" />
-                </NumberInput>
+              <FormControl display="flex" alignItems="center">
+                <Switch
+                  id="urgency-toggle"
+                  isChecked={form.urgency}
+                  onChange={(event) => handleChange("urgency", event.target.checked)}
+                  colorScheme="orange"
+                  mr={3}
+                />
+                <FormLabel htmlFor="urgency-toggle" mb={0}>
+                  Urgent
+                </FormLabel>
               </FormControl>
             </SimpleGrid>
             <FormControl>
-              <FormLabel>Effort</FormLabel>
               <EffortSlider
                 value={form.effort}
                 defaultValue={3}
                 onChange={handleEffortChange}
-                size="sm"
-                isCompact
-              />
-            </FormControl>
-            <FormControl>
-              <FormLabel>Tags</FormLabel>
-              <Input
-                placeholder="comma separated"
-                value={form.tags}
-                onChange={(event) => handleChange("tags", event.target.value)}
+                isAlwaysVisible
               />
             </FormControl>
             <FormControl>
               <FormLabel>Notes</FormLabel>
               <Textarea
+                variant="filled"
+                focusBorderColor="blue.400"
                 value={form.notes}
                 onChange={(event) => handleChange("notes", event.target.value)}
                 rows={3}
@@ -231,7 +251,17 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
             <Button variant="ghost" onClick={onClose}>
               Cancel
             </Button>
-            <Button colorScheme="blue" type="submit">
+            <Button
+              type="submit"
+              fontWeight="semibold"
+              borderRadius="full"
+              px={6}
+              color="white"
+              bgGradient={WORKSPACE_HEADER_MENU_STYLES.gradient}
+              boxShadow="md"
+              _hover={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "lg" }}
+              _active={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "lg" }}
+            >
               Add task
             </Button>
           </Stack>

--- a/src/components/AddTaskModal.jsx
+++ b/src/components/AddTaskModal.jsx
@@ -188,7 +188,7 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
               <FormControl>
                 <FormLabel>Due date</FormLabel>
                 <InputGroup>
-                  <InputLeftElement pointerEvents="none" color="gray.400">
+                  <InputLeftElement pointerEvents="none" color="gray.400" aria-hidden="true">
                     📅
                   </InputLeftElement>
                   <Input
@@ -246,26 +246,32 @@ export function AddTaskModal({ isOpen, onClose, onCreate, projects = [], onCreat
             </FormControl>
           </Stack>
         </ModalBody>
-        <ModalFooter>
-          <Stack direction="row" spacing={3}>
-            <Button variant="ghost" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              fontWeight="semibold"
-              borderRadius="full"
-              px={6}
-              color="white"
-              bgGradient={WORKSPACE_HEADER_MENU_STYLES.gradient}
-              boxShadow="md"
-              _hover={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "lg" }}
-              _active={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "lg" }}
+          <ModalFooter>
+            <Stack
+              direction={{ base: "column", sm: "row" }}
+              spacing={3}
+              w="full"
+              justify="flex-end"
             >
-              Add task
-            </Button>
-          </Stack>
-        </ModalFooter>
+              <Button variant="ghost" onClick={onClose} width={{ base: "100%", sm: "auto" }}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                fontWeight="semibold"
+                borderRadius="full"
+                px={6}
+                color="white"
+                bgGradient={WORKSPACE_HEADER_MENU_STYLES.gradient}
+                boxShadow="md"
+                _hover={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "lg" }}
+                _active={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "lg" }}
+                width={{ base: "100%", sm: "auto" }}
+              >
+                Add task
+              </Button>
+            </Stack>
+          </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/src/components/ProjectManagerModal.jsx
+++ b/src/components/ProjectManagerModal.jsx
@@ -19,6 +19,7 @@ import {
   Tooltip
 } from "@chakra-ui/react";
 import { DeleteIcon } from "@chakra-ui/icons";
+import { WORKSPACE_HEADER_MENU_STYLES } from "./componentTokens.js";
 
 export function ProjectListItem({ name, count, onRename, onDelete }) {
   const [value, setValue] = useState(name);
@@ -53,9 +54,16 @@ export function ProjectListItem({ name, count, onRename, onDelete }) {
         />
         <Button
           size="sm"
-          variant="ghost"
+          fontWeight="semibold"
+          borderRadius="full"
+          px={4}
+          variant="outline"
+          colorScheme="purple"
+          borderColor="purple.500"
           onClick={handleRename}
           isDisabled={value.trim() === name.trim()}
+          _hover={{ bg: "purple.50" }}
+          _active={{ bg: "purple.100" }}
         >
           Rename
         </Button>
@@ -63,6 +71,7 @@ export function ProjectListItem({ name, count, onRename, onDelete }) {
           <IconButton
             size="sm"
             variant="ghost"
+            colorScheme="red"
             aria-label={`Delete project ${name}`}
             icon={<DeleteIcon />}
             onClick={() => onDelete(name)}
@@ -159,7 +168,17 @@ export default function ProjectManagerModal({
                   }}
                   onKeyDown={handleKeyPress}
                 />
-                <Button colorScheme="blue" onClick={handleAdd}>
+                <Button
+                  onClick={handleAdd}
+                  fontWeight="semibold"
+                  borderRadius="full"
+                  px={5}
+                  color="white"
+                  bgGradient={WORKSPACE_HEADER_MENU_STYLES.gradient}
+                  boxShadow="md"
+                  _hover={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "lg" }}
+                  _active={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "lg" }}
+                >
                   Add
                 </Button>
               </HStack>

--- a/src/components/TaskEditor.jsx
+++ b/src/components/TaskEditor.jsx
@@ -38,8 +38,10 @@ export default function TaskEditor({
     title: task?.title ?? "",
     project: task?.project ?? "",
     due: task?.due ?? "",
-    importance: (task?.importance ?? 0) >= 3,
-    urgency: (task?.urgency ?? 0) >= 3,
+    importanceValue: task?.importance ?? undefined,
+    urgencyValue: task?.urgency ?? undefined,
+    importanceDirty: false,
+    urgencyDirty: false,
     effort: task?.effort ?? undefined,
     notes: task?.notes ?? "",
     done: Boolean(task?.done),
@@ -55,8 +57,10 @@ export default function TaskEditor({
       title: task?.title ?? "",
       project: task?.project ?? "",
       due: task?.due ?? "",
-      importance: (task?.importance ?? 0) >= 3,
-      urgency: (task?.urgency ?? 0) >= 3,
+      importanceValue: task?.importance ?? undefined,
+      urgencyValue: task?.urgency ?? undefined,
+      importanceDirty: false,
+      urgencyDirty: false,
       effort: task?.effort ?? undefined,
       notes: task?.notes ?? "",
       done: Boolean(task?.done),
@@ -101,6 +105,30 @@ export default function TaskEditor({
     setForm((prev) => ({ ...prev, effort: value }));
   }, []);
 
+  const handleImportanceToggle = useCallback((isChecked) => {
+    setForm((prev) => ({
+      ...prev,
+      importanceValue: isChecked
+        ? prev.importanceValue && prev.importanceValue >= 3
+          ? prev.importanceValue
+          : 5
+        : undefined,
+      importanceDirty: true
+    }));
+  }, []);
+
+  const handleUrgencyToggle = useCallback((isChecked) => {
+    setForm((prev) => ({
+      ...prev,
+      urgencyValue: isChecked
+        ? prev.urgencyValue && prev.urgencyValue >= 3
+          ? prev.urgencyValue
+          : 5
+        : undefined,
+      urgencyDirty: true
+    }));
+  }, []);
+
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault();
@@ -126,8 +154,10 @@ export default function TaskEditor({
         title,
         project: projectValue,
         due: form.due.trim() || undefined,
-        importance: form.importance ? 5 : undefined,
-        urgency: form.urgency ? 5 : undefined,
+        importance: form.importanceDirty
+          ? form.importanceValue ?? undefined
+          : task?.importance,
+        urgency: form.urgencyDirty ? form.urgencyValue ?? undefined : task?.urgency,
         effort: sanitizeNumber(form.effort),
         notes: form.notes.trim() || undefined,
         done: form.done
@@ -213,8 +243,8 @@ export default function TaskEditor({
               <FormControl display="flex" alignItems="center">
                 <Switch
                   id="edit-importance-toggle"
-                  isChecked={form.importance}
-                  onChange={(event) => handleChange("importance", event.target.checked)}
+                  isChecked={(form.importanceValue ?? 0) >= 3}
+                  onChange={(event) => handleImportanceToggle(event.target.checked)}
                   colorScheme="purple"
                   mr={3}
                 />
@@ -225,8 +255,8 @@ export default function TaskEditor({
               <FormControl display="flex" alignItems="center">
                 <Switch
                   id="edit-urgency-toggle"
-                  isChecked={form.urgency}
-                  onChange={(event) => handleChange("urgency", event.target.checked)}
+                  isChecked={(form.urgencyValue ?? 0) >= 3}
+                  onChange={(event) => handleUrgencyToggle(event.target.checked)}
                   colorScheme="orange"
                   mr={3}
                 />

--- a/src/components/TaskEditor.jsx
+++ b/src/components/TaskEditor.jsx
@@ -195,7 +195,7 @@ export default function TaskEditor({
               <FormControl>
                 <FormLabel>Due date</FormLabel>
                 <InputGroup>
-                  <InputLeftElement pointerEvents="none" color="gray.400">
+                  <InputLeftElement pointerEvents="none" color="gray.400" aria-hidden="true">
                     📅
                   </InputLeftElement>
                   <Input
@@ -266,6 +266,7 @@ export default function TaskEditor({
             leftIcon={<CheckIcon />}
             onClick={() => handleChange("done", !form.done)}
             aria-pressed={form.done}
+            type="button"
             size="md"
             fontWeight="semibold"
             borderRadius="full"

--- a/src/components/TaskEditor.jsx
+++ b/src/components/TaskEditor.jsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button,
   ButtonGroup,
-  Checkbox,
   FormControl,
   FormErrorMessage,
   FormLabel,
   Input,
+  InputGroup,
+  InputLeftElement,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -14,15 +15,16 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  NumberInput,
-  NumberInputField,
   Select,
   SimpleGrid,
   Stack,
+  Switch,
   Textarea
 } from "@chakra-ui/react";
+import { CheckIcon } from "@chakra-ui/icons";
 import EffortSlider from "../EffortSlider.jsx";
-import { sanitizeNumber, parseTags } from "../utils/taskFields.js";
+import { sanitizeNumber } from "../utils/taskFields.js";
+import { WORKSPACE_HEADER_MENU_STYLES } from "./componentTokens.js";
 
 export default function TaskEditor({
   task,
@@ -36,10 +38,9 @@ export default function TaskEditor({
     title: task?.title ?? "",
     project: task?.project ?? "",
     due: task?.due ?? "",
-    importance: task?.importance ?? "",
-    urgency: task?.urgency ?? "",
+    importance: (task?.importance ?? 0) >= 3,
+    urgency: (task?.urgency ?? 0) >= 3,
     effort: task?.effort ?? undefined,
-    tags: task?.tags ? task.tags.join(", ") : "",
     notes: task?.notes ?? "",
     done: Boolean(task?.done),
     projectMode: task?.project ? "existing" : "none",
@@ -54,10 +55,9 @@ export default function TaskEditor({
       title: task?.title ?? "",
       project: task?.project ?? "",
       due: task?.due ?? "",
-      importance: task?.importance ?? "",
-      urgency: task?.urgency ?? "",
+      importance: (task?.importance ?? 0) >= 3,
+      urgency: (task?.urgency ?? 0) >= 3,
       effort: task?.effort ?? undefined,
-      tags: task?.tags ? task.tags.join(", ") : "",
       notes: task?.notes ?? "",
       done: Boolean(task?.done),
       projectMode: task?.project ? "existing" : "none",
@@ -66,6 +66,16 @@ export default function TaskEditor({
     setError("");
     setProjectError("");
   }, [task]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    requestAnimationFrame(() => {
+      if (titleRef.current) {
+        titleRef.current.focus();
+        titleRef.current.select();
+      }
+    });
+  }, [isOpen]);
 
   const handleChange = useCallback((field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -116,10 +126,9 @@ export default function TaskEditor({
         title,
         project: projectValue,
         due: form.due.trim() || undefined,
-        importance: sanitizeNumber(form.importance),
-        urgency: sanitizeNumber(form.urgency),
+        importance: form.importance ? 5 : undefined,
+        urgency: form.urgency ? 5 : undefined,
         effort: sanitizeNumber(form.effort),
-        tags: parseTags(form.tags),
         notes: form.notes.trim() || undefined,
         done: form.done
       };
@@ -131,7 +140,15 @@ export default function TaskEditor({
   return (
     <Modal isOpen={isOpen} onClose={onCancel} initialFocusRef={titleRef} size="lg">
       <ModalOverlay />
-      <ModalContent as="form" onSubmit={handleSubmit}>
+      <ModalContent
+        as="form"
+        onSubmit={handleSubmit}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            handleSubmit(event);
+          }
+        }}
+      >
         <ModalHeader>Edit task</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
@@ -149,6 +166,9 @@ export default function TaskEditor({
               <FormControl isInvalid={Boolean(projectError)}>
                 <FormLabel>Project</FormLabel>
                 <Select
+                  variant="filled"
+                  focusBorderColor="blue.400"
+                  size="md"
                   value={form.projectMode === "new" ? "__new__" : form.project || ""}
                   onChange={(event) => handleProjectSelect(event.target.value)}
                 >
@@ -163,6 +183,8 @@ export default function TaskEditor({
                 {form.projectMode === "new" ? (
                   <Input
                     mt={2}
+                    variant="filled"
+                    focusBorderColor="blue.400"
                     placeholder="New project name"
                     value={form.newProjectName}
                     onChange={(event) => handleNewProjectNameChange(event.target.value)}
@@ -172,65 +194,116 @@ export default function TaskEditor({
               </FormControl>
               <FormControl>
                 <FormLabel>Due date</FormLabel>
-                <Input
-                  type="date"
-                  value={form.due}
-                  onChange={(event) => handleChange("due", event.target.value)}
-                />
+                <InputGroup>
+                  <InputLeftElement pointerEvents="none" color="gray.400">
+                    📅
+                  </InputLeftElement>
+                  <Input
+                    pl={10}
+                    type="date"
+                    variant="filled"
+                    focusBorderColor="blue.400"
+                    value={form.due}
+                    onChange={(event) => handleChange("due", event.target.value)}
+                  />
+                </InputGroup>
               </FormControl>
             </SimpleGrid>
             <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-              <FormControl>
-                <FormLabel>Importance</FormLabel>
-                <NumberInput
-                  min={0}
-                  value={form.importance}
-                  onChange={(valueString) => handleChange("importance", valueString)}
-                >
-                  <NumberInputField inputMode="numeric" />
-                </NumberInput>
+              <FormControl display="flex" alignItems="center">
+                <Switch
+                  id="edit-importance-toggle"
+                  isChecked={form.importance}
+                  onChange={(event) => handleChange("importance", event.target.checked)}
+                  colorScheme="purple"
+                  mr={3}
+                />
+                <FormLabel htmlFor="edit-importance-toggle" mb={0}>
+                  Important
+                </FormLabel>
               </FormControl>
-              <FormControl>
-                <FormLabel>Urgency</FormLabel>
-                <NumberInput
-                  min={0}
-                  value={form.urgency}
-                  onChange={(valueString) => handleChange("urgency", valueString)}
-                >
-                  <NumberInputField inputMode="numeric" />
-                </NumberInput>
+              <FormControl display="flex" alignItems="center">
+                <Switch
+                  id="edit-urgency-toggle"
+                  isChecked={form.urgency}
+                  onChange={(event) => handleChange("urgency", event.target.checked)}
+                  colorScheme="orange"
+                  mr={3}
+                />
+                <FormLabel htmlFor="edit-urgency-toggle" mb={0}>
+                  Urgent
+                </FormLabel>
               </FormControl>
             </SimpleGrid>
-            <EffortSlider value={form.effort} onChange={handleEffortChange} />
             <FormControl>
-              <FormLabel>Tags (comma separated)</FormLabel>
-              <Input
-                value={form.tags}
-                onChange={(event) => handleChange("tags", event.target.value)}
+              <EffortSlider
+                value={form.effort ?? 3}
+                defaultValue={3}
+                onChange={handleEffortChange}
+                isAlwaysVisible
               />
             </FormControl>
             <FormControl>
               <FormLabel>Notes</FormLabel>
               <Textarea
                 rows={4}
+                variant="filled"
+                focusBorderColor="blue.400"
                 value={form.notes}
                 onChange={(event) => handleChange("notes", event.target.value)}
               />
             </FormControl>
-            <Checkbox
-              isChecked={form.done}
-              onChange={(event) => handleChange("done", event.target.checked)}
-            >
-              Mark as done
-            </Checkbox>
           </Stack>
         </ModalBody>
-        <ModalFooter>
-          <ButtonGroup spacing={3}>
+        <ModalFooter
+          display="flex"
+          flexDirection={{ base: "column", sm: "row" }}
+          alignItems={{ base: "stretch", sm: "center" }}
+          justifyContent="space-between"
+          gap={3}
+        >
+          <Button
+            leftIcon={<CheckIcon />}
+            onClick={() => handleChange("done", !form.done)}
+            aria-pressed={form.done}
+            size="md"
+            fontWeight="semibold"
+            borderRadius="full"
+            px={6}
+            colorScheme="purple"
+            variant={form.done ? "solid" : "outline"}
+            color={form.done ? "white" : "purple.600"}
+            bgGradient={form.done ? WORKSPACE_HEADER_MENU_STYLES.gradient : undefined}
+            borderColor={form.done ? undefined : "purple.500"}
+            boxShadow={form.done ? "lg" : "md"}
+            _hover={
+              form.done
+                ? { bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "xl" }
+                : { bg: "purple.50" }
+            }
+            _active={
+              form.done
+                ? { bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "xl" }
+                : { bg: "purple.100" }
+            }
+          >
+            {form.done ? "Marked as Done" : "Mark as Done"}
+          </Button>
+          <ButtonGroup spacing={3} ml={{ base: 0, sm: "auto" }}>
             <Button variant="ghost" onClick={onCancel}>
               Cancel
             </Button>
-            <Button colorScheme="blue" type="submit">
+            <Button
+              type="submit"
+              fontWeight="semibold"
+              borderRadius="full"
+              px={6}
+              color="white"
+              bgGradient={WORKSPACE_HEADER_MENU_STYLES.gradient}
+              boxShadow="md"
+              _hover={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.hover, boxShadow: "lg" }}
+              _active={{ bgGradient: WORKSPACE_HEADER_MENU_STYLES.active, boxShadow: "lg" }}
+            >
               Save
             </Button>
           </ButtonGroup>


### PR DESCRIPTION
## Summary
- move the task completion control into the modal footer so it anchors to the bottom left of the editor
- update the button copy to read “Mark as Done” when the task is incomplete while keeping the celebratory styling when finished
- keep the save and cancel actions grouped on the right with responsive wrapping for narrow viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0be3ad948331a41810bb052de08c