### PR TITLE
feat: widen matrix and compact project cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -738,7 +738,7 @@ export default function App() {
   useEffect(() => () => clearPendingSave(), [clearPendingSave]);
 
   return (
-    <Container maxW="7xl" py={10}>
+    <Container maxW="8xl" px={{ base: 4, md: 6 }} py={10}>
       <Stack spacing={10}>
         <DemoDataBanner
           isVisible={showDemoBanner}
@@ -789,7 +789,7 @@ export default function App() {
                     onToggleFilter={toggleMatrixFilter}
                   />
                   <Box
-                    maxH={{ base: "none", lg: "70vh" }}
+                    maxH={{ base: "none", lg: "80vh" }}
                     overflowY={{ base: "visible", lg: "auto" }}
                     pr={{ lg: 2 }}
                   >

--- a/src/components/ProjectSection.jsx
+++ b/src/components/ProjectSection.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Badge, Box, Flex, Stack, Text, Textarea, Tooltip } from "@chakra-ui/react";
+import { Badge, Box, Flex, SimpleGrid, Text, Textarea, Tooltip } from "@chakra-ui/react";
 import TaskCard from "./TaskCard.jsx";
 import { getProjectMoodHighlight } from "../matrix.js";
 
@@ -168,7 +168,14 @@ export default function ProjectSection({
         </Text>
       ) : null}
       {items.length ? (
-        <Stack as="ul" spacing={3}>
+        <SimpleGrid
+          as="ul"
+          columns={{ base: 1, md: 2, xl: 3 }}
+          spacing={3}
+          listStyleType="none"
+          m={0}
+          p={0}
+        >
           {items.map((item) => (
             <TaskCard
               key={item.index}
@@ -181,7 +188,7 @@ export default function ProjectSection({
               highlightMode={highlightMode}
             />
           ))}
-        </Stack>
+        </SimpleGrid>
       ) : (
         <Text fontSize="sm" color="gray.400">
           {projectKey ? `Drag tasks here to assign to ${name}.` : "Drag tasks here to keep tasks unassigned."}

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -132,6 +132,7 @@ export default function TaskCard({
       display="flex"
       flexDirection="column"
       gap={2.5}
+      h="full"
     >
       <Flex align="flex-start" gap={3}>
         <MotionCircle


### PR DESCRIPTION
## Summary
- widen the workspace container and matrix viewport so quadrants have more breathing room
- arrange project task cards in a responsive grid for denser vertical scrolling
- ensure project task cards stretch to fill their grid cells for a consistent layout

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cb2183742083319726b17785c8d321