### PR TITLE
Rename project to FocusBadger

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -1,6 +1,6 @@
-# TaskBadger Data Format & LLM Prompts
+# FocusBadger Data Format & LLM Prompts
 
-TaskBadger stores everything in a single JSON Lines (`.jsonl`) file. Each line is either a **task record** or a **project record**. Blank lines and lines beginning with `#` are ignored.
+FocusBadger stores everything in a single JSON Lines (`.jsonl`) file. Each line is either a **task record** or a **project record**. Blank lines and lines beginning with `#` are ignored.
 
 ## Record Types
 
@@ -32,7 +32,7 @@ TaskBadger stores everything in a single JSON Lines (`.jsonl`) file. Each line i
 
 ### Add Tasks Prompt
 ```
-You are editing TaskBadger's tasks.jsonl file. Append new task records at the end.
+You are editing FocusBadger's tasks.jsonl file. Append new task records at the end.
 Requirements:
 - Follow the existing JSON Lines structure (one object per line).
 - Use ISO timestamps for `created` and `updated`.
@@ -45,7 +45,7 @@ Add tasks:
 
 ### Update Tasks Prompt
 ```
-You are updating TaskBadger's tasks.jsonl file. Modify only the specified tasks.
+You are updating FocusBadger's tasks.jsonl file. Modify only the specified tasks.
 Requirements:
 - Keep the file in JSON Lines format.
 - Update the `updated` timestamp on any changed task.
@@ -58,7 +58,7 @@ Requested edits:
 
 ### Project Maintenance Prompt
 ```
-You are curating TaskBadger projects in tasks.jsonl.
+You are curating FocusBadger projects in tasks.jsonl.
 Actions:
 - Add missing `{ "type":"project","name":"…" }` lines for these projects: …
 - Remove project records only if no task references them.
@@ -67,7 +67,7 @@ Actions:
 
 ### Conversational Assistant Prompt
 ```
-You are TaskBadger, a pragmatic scheduling assistant and life coach.
+You are FocusBadger, a pragmatic scheduling assistant and life coach.
 Workflow:
 1. Read the current tasks.jsonl content verbatim.
 2. Interview the user with concise follow-up questions. Challenge vague priorities, surface urgency/importance/effort, and infer projects when possible.
@@ -82,4 +82,4 @@ Rules:
 - Respect user constraints; optional data should be requested once, not pressed.
 ```
 
-Use these prompts verbatim or adapt them for automated workflows to keep TaskBadger's data consistent.
+Use these prompts verbatim or adapt them for automated workflows to keep FocusBadger's data consistent.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TaskBadger
+# FocusBadger
 
 Local first task board that stores everything in a human friendly JSONL file. Fast to edit, easy to diff, simple to automate with LLMs. Runs as a static site with a hot reload dev server and has unit tests.
 
@@ -155,7 +155,7 @@ Pull requests
 
 - `.github/workflows/deploy.yml` builds on pushes to `main` and publishes the site via GitHub Pages.
 - Enable Pages under **Settings → Pages → Build and deployment → GitHub Actions**.
-- The Vite config uses a relative `base`, so the published site works at `https://<user>.github.io/TaskBadger/` while still running locally.
+- The Vite config uses a relative `base`, so the published site works at `https://<user>.github.io/FocusBadger/` while still running locally.
 - File System Access API continues to read/write your local `tasks.jsonl` when opened in a compatible browser.
 
 ---

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>TaskBadger</title>
+    <title>FocusBadger</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "taskbadger",
+  "name": "focusbadger",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/public/tasks.sample.jsonl
+++ b/public/tasks.sample.jsonl
@@ -1,4 +1,4 @@
-# TaskBadger sample tasks
+# FocusBadger sample tasks
 {"type":"project","name":"Work"}
 {"type":"project","name":"Home"}
 {"title":"Write weekly report","project":"Work","importance":3,"urgency":2,"effort":2,"due":"2025-09-19","done":false}

--- a/src/components/DemoDataBanner.jsx
+++ b/src/components/DemoDataBanner.jsx
@@ -9,7 +9,7 @@ export default function DemoDataBanner({ isVisible, onLoadDemo, onDismiss }) {
     <Alert status="info" variant="left-accent" borderRadius="xl" alignItems="center">
       <AlertIcon />
       <Box flex="1">
-        <Text fontWeight="medium">Exploring TaskBadger online?</Text>
+        <Text fontWeight="medium">Exploring FocusBadger online?</Text>
         <Text fontSize="sm" color="gray.700">
           Load demo data to try the workspace without linking a local file. You can dismiss this banner after loading.
         </Text>

--- a/src/components/WorkspaceHeader.jsx
+++ b/src/components/WorkspaceHeader.jsx
@@ -27,7 +27,7 @@ export default function WorkspaceHeader({
   onSave,
   isLocalStorageEnabled = false,
   onToggleLocalStorage,
-  title = "TaskBadger",
+  title = "FocusBadger",
   subtitle = "Focus on what matters"
 }) {
   return (


### PR DESCRIPTION
## Summary
- rename project references from TaskBadger to FocusBadger across docs, HTML, and UI strings
- update package metadata and demo data banner to use the new FocusBadger name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb21abd99083319d393d72029508b9